### PR TITLE
Bump jmeter version to 5.4.3 fixing critical Log4j vulnerabilities

### DIFF
--- a/mqtt_jmeter/pom.xml
+++ b/mqtt_jmeter/pom.xml
@@ -6,7 +6,7 @@
     <version>2.0.2</version>
 
     <properties>
-        <jmeter-version>5.0</jmeter-version>
+        <jmeter-version>5.4.3</jmeter-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
CVE-2021-44228 and CVE-2021-45105, Jmeter changelog https://jmeter.apache.org/changes.html