### PR TITLE
MQTT Sub Sampler: Sample on 'Number or received messages' is missing timeout option  

### DIFF
--- a/mqtt_jmeter/pom.xml
+++ b/mqtt_jmeter/pom.xml
@@ -36,6 +36,12 @@
             <version>1.1.3</version>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/mqtt_jmeter/pom.xml
+++ b/mqtt_jmeter/pom.xml
@@ -3,10 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.xmeter</groupId>
     <artifactId>mqtt-jmeter</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
 
     <properties>
-        <jmeter-version>5.0</jmeter-version>
+        <jmeter-version>5.4.3</jmeter-version>
     </properties>
 
     <dependencies>

--- a/mqtt_jmeter/src/main/java/net/xmeter/Constants.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/Constants.java
@@ -37,6 +37,7 @@ public interface Constants {
 	public static final String RETAINED_MESSAGE = "mqtt.retained_message";
 	
 	public static final String SAMPLE_CONDITION_VALUE = "mqtt.sample_condition_value";
+	public static final String SAMPLE_CONDITION_VALUE_OPT = "mqtt.sample_condition_value_opt";
 	public static final String SAMPLE_CONDITION = "mqtt.sample_condition";
 	
 	public static final String TIME_STAMP_SEP_FLAG = "ts_sep_flag";
@@ -84,6 +85,7 @@ public interface Constants {
 	public static final String DEFAULT_CONN_RECONN_ATTAMPT_MAX = "0";
 	
 	public static final String DEFAULT_SAMPLE_VALUE_COUNT = "1";
+	public static final String DEFAULT_SAMPLE_VALUE_COUNT_TIMEOUT = "5000";
 	public static final String DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC = "1000";
 	
 	public static final String DEFAULT_MESSAGE_FIX_LENGTH = "1024";

--- a/mqtt_jmeter/src/main/java/net/xmeter/gui/PubSamplerUI.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/gui/PubSamplerUI.java
@@ -3,9 +3,7 @@ package net.xmeter.gui;
 import java.awt.BorderLayout;
 import java.util.logging.Logger;
 
-import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -25,6 +23,8 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 	private static final long serialVersionUID = 2479085966683186422L;
 	private static final Logger logger = Logger.getLogger(PubSamplerUI.class.getCanonicalName());
 
+
+	private final JLabel qosLabel = new JLabel("QoS Level:");
 	private JLabeledChoice qosChoice;
 	private final JLabeledTextField retainedMsg = new JLabeledTextField("Retained messages:", 1);
 	private final JLabeledTextField topicName = new JLabeledTextField("Topic name:");
@@ -59,6 +59,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		qosChoice.addChangeListener(this);
 
 		JPanel optsPanel = new HorizontalPanel();
+		optsPanel.add(qosLabel);
 		optsPanel.add(qosChoice);
 		optsPanel.add(retainedMsg);
 		optsPanel.add(topicName);
@@ -129,7 +130,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		super.configure(element);
 		PubSampler sampler = (PubSampler) element;
 		
-		if(sampler.getQOS().trim().indexOf(JMETER_VARIABLE_PREFIX) == -1){
+		if(!sampler.getQOS().trim().contains(JMETER_VARIABLE_PREFIX)){
 			this.qosChoice.setSelectedIndex(Integer.parseInt(sampler.getQOS()));	
 		} else {
 			this.qosChoice.setText(sampler.getQOS());
@@ -161,7 +162,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.configureTestElement(sampler);
 		sampler.setTopic(this.topicName.getText());
 		
-		if(this.qosChoice.getText().indexOf(JMETER_VARIABLE_PREFIX) == -1) {
+		if(!this.qosChoice.getText().contains(JMETER_VARIABLE_PREFIX)) {
 			int qos = QOS_0;
 			try {
 				qos = Integer.parseInt(this.qosChoice.getText());
@@ -193,7 +194,7 @@ public class PubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.timestamp.setSelected(false);
 		
 		this.messageTypes.setSelectedIndex(0);
-		this.stringLength.setText(String.valueOf(DEFAULT_MESSAGE_FIX_LENGTH));
+		this.stringLength.setText(DEFAULT_MESSAGE_FIX_LENGTH);
 		this.sendMessage.setText("");
 	}
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/gui/SubSamplerUI.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/gui/SubSamplerUI.java
@@ -3,9 +3,7 @@ package net.xmeter.gui;
 import java.awt.BorderLayout;
 import java.util.logging.Logger;
 
-import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -22,11 +20,15 @@ import net.xmeter.samplers.SubSampler;
 public class SubSamplerUI extends AbstractSamplerGui implements Constants, ChangeListener{
 	private static final long serialVersionUID = 1715399546099472610L;
 	private static final Logger logger = Logger.getLogger(SubSamplerUI.class.getCanonicalName());
-	
+
+	private final JLabel qosLabel = new JLabel("QoS Level:");
+	private final JLabel sampleOnLabel = new JLabel("Sample on:");
+
 	private JLabeledChoice qosChoice;
 	private JLabeledChoice sampleOnCondition;
 	
 	private final JLabeledTextField sampleConditionValue = new JLabeledTextField("");
+	private final JLabeledTextField sampleConditionValue2 = new JLabeledTextField("Timeout (ms):");
 	private final JLabeledTextField topicNames = new JLabeledTextField("Topic name(s):");
 	
 	private JCheckBox debugResponse = new JCheckBox("Debug response");
@@ -55,6 +57,7 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		sampleOnCondition = new JLabeledChoice("Sample on:", new String[] {SAMPLE_ON_CONDITION_OPTION1, SAMPLE_ON_CONDITION_OPTION2});
 
 		JPanel optsPanel1 = new HorizontalPanel();
+		optsPanel1.add(qosLabel);
 		optsPanel1.add(qosChoice);
 		optsPanel1.add(topicNames);
 		topicNames.setToolTipText("A list of topics to be subscribed to, comma-separated.");
@@ -63,10 +66,14 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		
 		JPanel optsPanel3 = new HorizontalPanel();
 		sampleOnCondition.addChangeListener(this);
+		optsPanel3.add(sampleOnLabel);
 		optsPanel3.add(sampleOnCondition);
 		optsPanel3.add(sampleConditionValue);
+		optsPanel3.add(sampleConditionValue2);
 		sampleOnCondition.setToolTipText("When sub sampler should report out.");
 		sampleConditionValue.setToolTipText("Please specify an integer value great than 0, other values will be ignored.");
+		sampleConditionValue2.setToolTipText("Timeout in sec");
+		sampleConditionValue2.setEnabled(false);
 		optsPanelCon.add(optsPanel3);
 		
 		JPanel optsPanel2 = new HorizontalPanel();
@@ -93,7 +100,7 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		super.configure(element);
 		SubSampler sampler = (SubSampler) element;
 
-		if(sampler.getQOS().trim().indexOf(JMETER_VARIABLE_PREFIX) == -1){
+		if(!sampler.getQOS().trim().contains(JMETER_VARIABLE_PREFIX)){
 			this.qosChoice.setSelectedIndex(Integer.parseInt(sampler.getQOS()));	
 		} else {
 			this.qosChoice.setText(sampler.getQOS());
@@ -104,10 +111,13 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.debugResponse.setSelected(sampler.isDebugResponse());
 		this.sampleOnCondition.setText(sampler.getSampleCondition());
 
-		if(SAMPLE_ON_CONDITION_OPTION1.equalsIgnoreCase(sampleOnCondition.getText())) {
+		if (SAMPLE_ON_CONDITION_OPTION1.equalsIgnoreCase(sampleOnCondition.getText())) {
 			this.sampleConditionValue.setText(sampler.getSampleElapsedTime());
-		} else if(SAMPLE_ON_CONDITION_OPTION2.equalsIgnoreCase(sampleOnCondition.getText())) {
+			this.sampleConditionValue2.setEnabled(false);
+		} else if (SAMPLE_ON_CONDITION_OPTION2.equalsIgnoreCase(sampleOnCondition.getText())) {
 			this.sampleConditionValue.setText(sampler.getSampleCount());
+			this.sampleConditionValue2.setEnabled(true);
+			this.sampleConditionValue2.setText(sampler.getSampleCountTimeout());
 		}
 	}
 
@@ -126,7 +136,7 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.configureTestElement(sampler);
 		sampler.setTopics(this.topicNames.getText());
 		
-		if(this.qosChoice.getText().indexOf(JMETER_VARIABLE_PREFIX) == -1) {
+		if(!this.qosChoice.getText().contains(JMETER_VARIABLE_PREFIX)) {
 			int qos = QOS_0;
 			try {
 				qos = Integer.parseInt(this.qosChoice.getText());
@@ -151,6 +161,7 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 			sampler.setSampleElapsedTime(this.sampleConditionValue.getText());
 		} else if(SAMPLE_ON_CONDITION_OPTION2.equalsIgnoreCase(sampleOnCondition.getText())) {
 			sampler.setSampleCount(this.sampleConditionValue.getText());
+			sampler.setSampleCountTimeout(this.sampleConditionValue2.getText());
 		}
 	}
 	
@@ -163,17 +174,21 @@ public class SubSamplerUI extends AbstractSamplerGui implements Constants, Chang
 		this.debugResponse.setSelected(false);
 		this.sampleOnCondition.setText(SAMPLE_ON_CONDITION_OPTION1);
 		this.sampleConditionValue.setText(DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC);
+		this.sampleConditionValue2.setEnabled(false);
+		this.sampleConditionValue2.setText(DEFAULT_SAMPLE_VALUE_COUNT_TIMEOUT);
 	}
 
 	@Override
 	public void stateChanged(ChangeEvent e) {
 		if(this.sampleOnCondition == e.getSource()) {
-			if(SAMPLE_ON_CONDITION_OPTION1.equalsIgnoreCase(sampleOnCondition.getText())) {
+			if (SAMPLE_ON_CONDITION_OPTION1.equalsIgnoreCase(sampleOnCondition.getText())) {
 				sampleConditionValue.setText(DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC);
-			} else if(SAMPLE_ON_CONDITION_OPTION2.equalsIgnoreCase(sampleOnCondition.getText())) {
+				sampleConditionValue2.setEnabled(false);
+			} else if (SAMPLE_ON_CONDITION_OPTION2.equalsIgnoreCase(sampleOnCondition.getText())) {
 				sampleConditionValue.setText(DEFAULT_SAMPLE_VALUE_COUNT);
+				sampleConditionValue2.setText(DEFAULT_SAMPLE_VALUE_COUNT_TIMEOUT);
+				sampleConditionValue2.setEnabled(true);
 			}
 		}
 	}
-	
 }

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/PubSampler.java
@@ -4,7 +4,7 @@ import java.text.MessageFormat;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;

--- a/mqtt_jmeter/src/main/java/net/xmeter/samplers/SubSampler.java
+++ b/mqtt_jmeter/src/main/java/net/xmeter/samplers/SubSampler.java
@@ -30,6 +30,7 @@ public class SubSampler extends AbstractMQTTSampler {
 	private boolean sampleByTime = true; // initial values
 	private int sampleElapsedTime = 1000; 
 	private int sampleCount = 1;
+	private int sampleCountTimeout = 5000;
 
 	private transient ConcurrentLinkedQueue<SubBean> batches = new ConcurrentLinkedQueue<>();
 	private boolean printFlag = false;
@@ -67,10 +68,14 @@ public class SubSampler extends AbstractMQTTSampler {
 	public void setSampleCount(String count) {
 		setProperty(SAMPLE_CONDITION_VALUE, count);
 	}
-	
-	public String getSampleElapsedTime() {
-		return getPropertyAsString(SAMPLE_CONDITION_VALUE, DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC);
+
+	public String getSampleCountTimeout() { return getPropertyAsString(SAMPLE_CONDITION_VALUE_OPT, DEFAULT_SAMPLE_VALUE_COUNT_TIMEOUT); }
+
+	public void setSampleCountTimeout(String timeout) {
+		setProperty(SAMPLE_CONDITION_VALUE_OPT, timeout);
 	}
+
+	public String getSampleElapsedTime() { return getPropertyAsString(SAMPLE_CONDITION_VALUE, DEFAULT_SAMPLE_VALUE_ELAPSED_TIME_MILLI_SEC);}
 	
 	public void setSampleElapsedTime(String elapsedTime) {
 		setProperty(SAMPLE_CONDITION_VALUE, elapsedTime);
@@ -110,6 +115,7 @@ public class SubSampler extends AbstractMQTTSampler {
 				sampleElapsedTime = Integer.parseInt(getSampleElapsedTime());
 			} else {
 				sampleCount = Integer.parseInt(getSampleCount());
+				sampleCountTimeout = Integer.parseInt(getSampleCountTimeout());
 			}
 		} catch (NumberFormatException e) {
 			return fillFailedResult(result, "510", "Unrecognized value for sample elapsed time or message count.");
@@ -118,7 +124,7 @@ public class SubSampler extends AbstractMQTTSampler {
 		if (sampleByTime && sampleElapsedTime <=0 ) {
 			return fillFailedResult(result, "511", "Sample on elapsed time: must be greater than 0 ms.");
 		} else if (sampleCount < 1) {
-			return fillFailedResult(result, "512", "Sample on message count: must be greater than 1.");
+			return fillFailedResult(result, "512", "Sample on message count: must be equal or greater then 1.");
 		}
 		
 		final String topicsName= getTopics();
@@ -155,18 +161,22 @@ public class SubSampler extends AbstractMQTTSampler {
 			}
 		} else {
 			synchronized (dataLock) {
-				int receivedCount1 = (batches.isEmpty() ? 0 : batches.element().getReceivedCount());;
-				boolean needWait = false;
-				if(receivedCount1 < sampleCount) {
-					needWait = true;
-				}
-				
-				if(needWait) {
+				int receivedCount1 = (batches.isEmpty() ? 0 : batches.element().getReceivedCount());
+				if (receivedCount1 < sampleCount) {
 					try {
-						dataLock.wait();
+						if (sampleCountTimeout != 0) {
+							dataLock.wait(sampleCountTimeout);
+						} else {
+							dataLock.wait();
+						}
 					} catch (InterruptedException e) {
 						logger.log(Level.INFO, "Received exception when waiting for notification signal", e);
 					}
+				}
+				receivedCount1 = (batches.isEmpty() ? 0 : batches.element().getReceivedCount());
+				if (receivedCount1 < sampleCount) {
+					// TODO: is that the way to do it?
+					return fillFailedResult(result, "502", "Failed: No message received on topic: " + topicsName + " (Timeout after " + sampleCountTimeout + "ms)");
 				}
 				result.sampleStart();
 				return produceResult(result, topicsName);


### PR DESCRIPTION
Hi, 
i think a timeout option  is missing in the 'MQTT Sub Sampler' with SampleOnCondition set to 'Number or received messages'.
It basicly deadlocks a thread when an awaited message never was published. 
With our customer we have usecases were we need to measure the time it takes from publishing a messages and receiving a response on different topics (with processing backends involved). 

Test/Script would be something like this:
**thread1** publishes a message on **_topic1_** -> a backend system receives and processes the message and sends a response to **_topic2_** -> **thread1** meanwhile subscribed to **topic2** and waits for that message/response.

We want to be able to at least measure the time from publishing the message on topic1 to receiving the response on topic2. Also, consider the backend having issues and never sends the response. So,  **thread1** that subscribed to **_topic2_** would then wait basically forever for that one message/response to arrive and those being actually caught in a deadlock situation. 

So, in that situation, I think the easiest thing to do would be to implement a [optional] timeout setting. Were, when the sampler runs into the timeout the sampler fails and it is considered an error.

I have implemented such a timeout option. Please have a look.

Regards

SampleOnCondition: 'Number or received messages' -> timeoutTextField enabled
![image](https://user-images.githubusercontent.com/33349275/171960284-58a07793-abcb-454b-94c1-c03e43586e22.png)
If timeout is set to 0 the Sub Sampler behaves like before and waits for all messages to arrive (never timesout)

SampleOnCondition: 'specified elapsed time (ms)' -> timeoutTextField disabled
![image](https://user-images.githubusercontent.com/33349275/171960344-2494338c-f6cb-4acd-a32c-1317b5744c32.png)
